### PR TITLE
Use "bash bootstrap.sh"

### DIFF
--- a/web/src/routes/docs/installation/+page.svelte
+++ b/web/src/routes/docs/installation/+page.svelte
@@ -3,7 +3,7 @@
 	const scriptInstallCommands = [
 	  `wget "${bootstrapLink}"`,
 		`export SHOKKU_LETSENCRYPT_EMAIL="foo@example.com"`,
-	  `bash install.sh`,
+	  `bash bootstrap.sh`,
 	];
 </script>
 


### PR DESCRIPTION
Right now the `wget` command creates `bootstrap.sh`, not `install.sh`