### PR TITLE
Fix #18: viewing DB (MySQL, PostgreSQL, etc...) throws error

### DIFF
--- a/internal/server/api/services/services.go
+++ b/internal/server/api/services/services.go
@@ -107,7 +107,7 @@ func GetServiceInfo(e *env.Env, c echo.Context) error {
 	}
 
 	info := map[string]string{
-		"version": "", "internal-ip": "", "status": "", // "dsn": "",
+		"internal-ip": "", "status": "", // "dsn": "",
 	}
 	for key := range info {
 		cmd := fmt.Sprintf("%s:info %s --%s", req.Type, req.Name, key)


### PR DESCRIPTION
This PR fix #18

## Issue
  - Encountered a data retrieval error when attempting to view a database (MySQL, PostgreSQL, etc...).

## Cause
  - Invalid flags were being passed to dokku during the request for retrieving database details.

## Fixes
  - Corrected the handling of flags to ensure only valid flags are used.

## Result
  - Database details are now correctly fetched without errors.
  ![2025-04-07_03h01_55](https://github.com/user-attachments/assets/63020760-6146-49a7-a5bb-5e62d9e2eea5)
