### PR TITLE
Add support for Dokku Storage Mounts

### DIFF
--- a/internal/server/dto/apps.go
+++ b/internal/server/dto/apps.go
@@ -288,9 +288,7 @@ type AlterAppStorageRequest struct {
 	Name       string `json:"name" validate:"appName"`
 	RestartApp bool   `json:"restart"`
 
-	// TODO: validation for these
-	StorageType  string `json:"selectedType"`
-	HostDir      string `json:"hostDir" validate:"gte=2,alphanum"`
+	HostDir      string `json:"hostDir"`
 	ContainerDir string `json:"mountDir"`
 }
 

--- a/ui/src/routes/app/[name]/storage/CreateStorageModal.svelte
+++ b/ui/src/routes/app/[name]/storage/CreateStorageModal.svelte
@@ -8,12 +8,13 @@
   export let loading;
   export let error;
 
+  const dokkuDir = "/var/lib/dokku/data/storage/";
   const storageTypes = {
-    "New Storage": { label: "Storage Name" },
-    // "Mount Existing Directory": {"label": "Existing Path to Mount"}
+    "Docker Volume": { label: "Volume Name" },
+    "Dokku Storage": { label: dokkuDir },
   };
 
-  let selectedType = "New Storage";
+  let selectedType = "Dokku Storage";
   let hostDir = "";
   let mountDir = "";
   let typeOptions = Object.keys(storageTypes);
@@ -21,7 +22,8 @@
   const dispatch = createEventDispatcher();
 
   const dispatchCreateStorage = () => {
-    const options = { selectedType, hostDir, mountDir };
+    const fullHostDir = selectedType === "Dokku Storage" ? `${dokkuDir}${hostDir}` : hostDir;
+    const options = { hostDir: fullHostDir, mountDir };
     dispatch("create", options);
   };
 </script>

--- a/ui/src/routes/app/[name]/storage/StorageMount.svelte
+++ b/ui/src/routes/app/[name]/storage/StorageMount.svelte
@@ -32,20 +32,16 @@
 </script>
 
 <div class="flex flex-row gap-2">
-  <div class="flex items-center" class:flex-grow={!isDokkuManaged}>
-    <label class="input-group input-group-md" class:hidden={isDokkuManaged}>
-      <span class="w-auto">Mounted Path</span>
+  <div class="flex items-center flex-grow">
+    <label class="input-group input-group-md">
+      <span class="w-auto">{isDokkuManaged ? "Dokku Storage Name" : "Docker Volume Name"}</span>
       <input
         type="text"
-        value={hostDir}
-        class="input input-md input-bordered"
+        value={isDokkuManaged ? hostDokkuDir : hostDir}
+        class="input input-md input-bordered flex-grow"
         disabled
-        class:flex-grow={!isDokkuManaged}
       />
     </label>
-    <div class="" class:hidden={!isDokkuManaged}>
-      <span class="font-bold">{hostDokkuDir}</span>
-    </div>
   </div>
 
   <div class="flex-grow">


### PR DESCRIPTION
## Summary

- Added support for mounting **Dokku Storage** in addition to existing **Docker Volume** mounts.  
  This uses the **Dokku-recommended** `/var/lib/dokku/data/storage/` path, which allows us to use `dokku storage:ensure-directory`.

- By default, Dokku Storage is now selected.  
  If there are any concerns, feel free to switch back to the previous Docker Volume setup — it's still available via the dropdown menu.

## Motivation

- Dokku Storage directories do not require manual `chown`, which simplifies mount preparation and avoids potential permission issues.

## Image

![2025-04-10_01h10_07](https://github.com/user-attachments/assets/a76c54de-748e-430c-a7af-a2cb92e9ff4a)
